### PR TITLE
Support for Node 6 + better error debug information

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/esdoc2/esdoc2"
   },
   "engines": {
-    "node": ">= 8",
+    "node": ">= 6",
     "yarn": ">= 1"
   },
   "scripts": {

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -13,6 +13,10 @@ if (process.env.CI) {
   mocha.reporter('mocha-junit-reporter')
 }
 
+process.on('unhandledRejection', (reason, p) => {
+  console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
+});
+
 init.then(() => {
   const tests = process.argv.slice(2);
   tests.forEach((test) => {

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -14,7 +14,7 @@ if (process.env.CI) {
 }
 
 process.on('unhandledRejection', (reason, p) => {
-  console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
+  console.error('Unhandled Rejection at: Promise', p, 'reason:', reason);
 });
 
 init.then(() => {

--- a/src/ESDocCLI.js
+++ b/src/ESDocCLI.js
@@ -36,7 +36,7 @@ export default class ESDocCLI {
     }
 
     process.on('unhandledRejection', (reason, p) => {
-      console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
+      console.error('Unhandled Rejection at: Promise', p, 'reason:', reason);
     });
   }
 

--- a/src/ESDocCLI.js
+++ b/src/ESDocCLI.js
@@ -34,6 +34,10 @@ export default class ESDocCLI {
       this._showVersion();
       process.exit(0);
     }
+
+    process.on('unhandledRejection', (reason, p) => {
+      console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
+    });
   }
 
   /**

--- a/test/integration-test/plugin/MyPlugin1.test.js
+++ b/test/integration-test/plugin/MyPlugin1.test.js
@@ -3,7 +3,8 @@ import fs from 'fs';
 import {find} from '../util';
 
 describe('test/plugin/MyPlugin1:', ()=>{
-  it('calls handlers', async ()=>{
+  it('calls handlers', () => {
+    return new Promise((resolve, reject) => {
       const callInfo = require('./MyPlugin1').callInfo;
       assert.deepEqual(callInfo.handlerNames, {
         onStart: true,
@@ -16,7 +17,10 @@ describe('test/plugin/MyPlugin1:', ()=>{
         onHandleContent: true,
         onComplete: true
       });
-      assert.equal(callInfo.usedParser, true);  
+      assert.equal(callInfo.usedParser, true);
+
+      resolve();
+    });
   });
 
   it('modified input', ()=>{

--- a/test/integration-test/plugin/MyPlugin2.test.js
+++ b/test/integration-test/plugin/MyPlugin2.test.js
@@ -1,7 +1,8 @@
 import assert from 'assert';
 
 describe('test/plugin/MyPlugin2:', ()=>{
-  it('calls handlers', async ()=>{
+  it('calls handlers', () => {
+    return new Promise((resolve, reject) => {
       const callInfo = require('./MyPlugin2').callInfo;
       assert.deepEqual(callInfo.handlerNames, {
         onStart: true,
@@ -14,5 +15,8 @@ describe('test/plugin/MyPlugin2:', ()=>{
         onHandleContent: true,
         onComplete: true
       });
+
+      resolve();
+    });
   });
 });


### PR DESCRIPTION
Hi!

I believe this is all that is needed for Node 6 support. Tests seem to pass just fine with Promises, even though I'm not sure my migration (from `async` to `Promise`) is correct. I've modified it to cause an error and it's detected just fine, so I believe this should be ok.

```
ricardo@desenv4 ~/Development/esdoc2 $ nvm current
v6.12.1
ricardo@desenv4 ~/Development/esdoc2 $ yarn test
(...)
  167 passing (49ms)
  5 pending
```

I've also added some extra debug information in case of unhandled rejections, so we can better debug the code in case something go wrong.


Cheers,

Ricardo