### PR TITLE
Added mkdip and npmlog as runtime deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "ice-cap": "0.0.4",
     "marked": "0.3.6",
     "minimist": "1.2.0",
+    "mkdirp": "^0.5.1",
+    "npmlog": "^4.1.2",
     "taffydb": "2.7.3"
   },
   "devDependencies": {
@@ -66,7 +68,6 @@
     "mocha": "4.0.1",
     "mocha-junit-reporter": "^1.15.0",
     "node-static": "^0.7.10",
-    "npmlog": "^4.1.2",
     "nyc": "11.3.0",
     "pre-commit": "^1.2.2"
   },


### PR DESCRIPTION
As commented (https://github.com/esdoc2/esdoc2/issues/2#issuecomment-351353778), `mkdirp` and `npmlog` as required as runtime dependencies. I believe it was working before this because the dev dependencies included `npmlog`, and `mkdirp` was included a package that eventually required it.

This change forces both packages to be available in production as well.