### PR TITLE
Preimported plugins

### DIFF
--- a/src/Plugin/Plugin.js
+++ b/src/Plugin/Plugin.js
@@ -29,7 +29,9 @@ class Plugin {
     /* eslint-disable global-require */
     for (const item of this._plugins) {
       let plugin;
-      if (item.name.match(/^[.\/]/)) {
+      if (item.plugin) {
+        plugin = item.plugin;
+      } else if (item.name.match(/^[.\/]/)) {
         const pluginPath = path.resolve(item.name);
         plugin = require(pluginPath);
       } else {


### PR DESCRIPTION
Specifically the current import lines rely on node having flattened the structure of dependent packages in order to work. This is not always the case. The easiest fix is to simply let plugins which require other plugins do that themselves. In their location, the correct node_modules folders will be searched, and they can pass the instance to esdoc2.